### PR TITLE
[HOTFIX] explicit return success exit code in post-merge hook

### DIFF
--- a/hooks/post-merge.sh
+++ b/hooks/post-merge.sh
@@ -9,3 +9,5 @@ check_file() {
 
 echo "==> Check package.json for changes and reinstall packages when necessary"
 check_file "package.json" "npm install && npm prune"
+
+exit 0


### PR DESCRIPTION
we got npm error when running this hook via husky utility
```
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! lms@0.0.0 post-merge: `./node_modules/ng-git-hooks/hooks/post-merge.sh`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the lms@0.0.0 post-merge script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/pl/.npm/_logs/2022-02-07T15_45_08_493Z-debug.log
husky - post-merge hook exited with code 1 (error)
```