### PR TITLE
[ENIGMADS-464] add a report of the  comments without a description

### DIFF
--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -77,7 +77,7 @@ fi;
 
 if [ -f "$STYLELINT_CONFIG" ] && [ -n "$stylesToLint" ]; then
   echo "==> Checking Stylelint errors in staged files";
-  echo "$stylesToLint" | xargs ./node_modules/.bin/stylelint --fix
+  echo "$stylesToLint" | xargs ./node_modules/.bin/stylelint --fix --rdd
 
   echo "==> Staging formatted .scss, .css files"
   echo "$stylesToLint" | xargs git add


### PR DESCRIPTION
https://studytube.atlassian.net/browse/ENIGMADS-464

_**Using `stylelint-disable` without description throws an error by Stylelint**_

<img width="1353" alt="Screenshot 2022-08-19 at 14 18 57" src="https://user-images.githubusercontent.com/20286643/185621232-e853225e-aaf8-42e1-8094-d5630e4ffe96.png">


_**Using `stylelint-disable` with description passes linting**_

<img width="1654" alt="Screenshot 2022-08-19 at 14 19 30" src="https://user-images.githubusercontent.com/20286643/185621239-f0ff0294-3c1a-4934-a4e8-8b7b44ae84b4.png">

